### PR TITLE
Update spark http server and jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <url>https://github.com/catalogueglobal/datatools-server.git</url>
     </scm>
     <properties>
-        <jackson.version>[2.9.5,)</jackson.version>
+        <jackson.version>2.9.6</jackson.version>
     </properties>
     <build>
         <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <url>https://github.com/catalogueglobal/datatools-server.git</url>
     </scm>
     <properties>
-        <jackson.version>2.9.0</jackson.version>
+        <jackson.version>[2.9.5,)</jackson.version>
     </properties>
     <build>
         <resources>
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>2.5</version>
+            <version>[2.7.2,)</version>
         </dependency>
 
         <!-- Logging -->

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,7 @@
         <dependency>
             <groupId>com.sparkjava</groupId>
             <artifactId>spark-core</artifactId>
-            <version>[2.7.2,)</version>
+            <version>2.7.2</version>
         </dependency>
 
         <!-- Logging -->

--- a/src/main/java/com/conveyal/datatools/manager/utils/json/JsonManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/utils/json/JsonManager.java
@@ -38,6 +38,8 @@ public class JsonManager<T> {
         this.om = new ObjectMapper();
         // previous model for gtfs validation errors
 //        om.addMixIn(InvalidValue.class, InvalidValueMixIn.class);
+        // TODO: Removes extraneous mixins? These may be needed to import data from MapDB-backed versions of this
+        //  software to the MongoDB-backed system.
         om.addMixIn(Rectangle2D.class, Rectangle2DMixIn.class);
         SimpleModule deser = new SimpleModule();
 


### PR DESCRIPTION
These are bug fixes for Spark (the HTTP server we use) and Jackson (JSON serialization). There are vulnerabilities in the versions we currently depend on, so this PR is simply to bump up to patch the following items flagged by GitHub:
- Jackson https://nvd.nist.gov/vuln/detail/CVE-2017-17485
- Spark https://nvd.nist.gov/vuln/detail/CVE-2016-9177

Note: a successful CI build on Travis depends on #17, so that should be merged into `dev` first.