### PR TITLE
Mtc tweaks + gtfs-lib update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>4.2.1</version>
+            <version>4.2.2</version>
         </dependency>
 
         <!-- Used for data-tools application database -->

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -270,7 +270,12 @@ public class FeedVersionController  {
                 // NOTE: If the MTC extension is enabled, the parent feed source's publishedVersionId will not be updated to the
                 // version's namespace until the FeedUpdater has successfully downloaded the feed from the share S3 bucket.
                 Date publishedDate = new Date();
-                return Persistence.feedVersions.updateField(version.id, "sentToExternalPublisher", publishedDate);
+                // Set "sent" timestamp to now and reset "processed" timestamp (in the case that it had previously been
+                // published as the active version.
+                version.sentToExternalPublisher = publishedDate;
+                version.processedByExternalPublisher = null;
+                Persistence.feedVersions.replace(version.id, version);
+                return version;
             }
         } catch (Exception e) {
             haltWithMessage(req, 500, "Could not publish feed.", e);


### PR DESCRIPTION
Bump gtfs-lib to 4.2.2 and tweak the feed version publishing controller to reset the `FeedVersion#processedByExternalPublisher` value to `null` if it is ever re-published.