### PR TITLE
Release: bump snapshot version for maven-semantic-release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.conveyal</groupId>
     <artifactId>datatools-server</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.1-SNAPSHOT</version>
 
     <licenses>
         <license>


### PR DESCRIPTION
maven-semantic-release requires the snapshot version to be at most one patch version higher than the current tagged release for the github repository.