### PR TITLE
Fix gtfs plus upload

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/utils/Scheduler.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/Scheduler.java
@@ -18,6 +18,7 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -25,6 +26,7 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
 import static com.conveyal.datatools.common.utils.Utils.getTimezone;
+import static com.google.common.collect.Multimaps.synchronizedListMultimap;
 
 /**
  * This class centralizes the logic associated with scheduling and cancelling tasks (organized as a {@link ScheduledJob})
@@ -40,9 +42,11 @@ public class Scheduler {
     // Scheduled executor that handles running scheduled jobs.
     public final static ScheduledExecutorService schedulerService = Executors.newScheduledThreadPool(1);
     /** Stores {@link ScheduledJob} objects containing scheduled tasks keyed on the tasks's associated {@link FeedSource} ID. */
-    public final static ListMultimap<String, ScheduledJob> scheduledJobsForFeedSources = ArrayListMultimap.create();
+    public final static ListMultimap<String, ScheduledJob> scheduledJobsForFeedSources =
+        synchronizedListMultimap(ArrayListMultimap.create());
     /** Stores {@link ScheduledJob} objects containing scheduled tasks keyed on the tasks's associated {@link Project} ID. */
-    public final static ListMultimap<String, ScheduledJob> scheduledJobsForProjects = ArrayListMultimap.create();
+    public final static ListMultimap<String, ScheduledJob> scheduledJobsForProjects =
+        synchronizedListMultimap(ArrayListMultimap.create());
 
     /**
      * A method to initialize all scheduled tasks upon server startup.
@@ -83,10 +87,14 @@ public class Scheduler {
         // First get the list of jobs belonging to the id (e.g., all jobs related to a feed source).
         List<ScheduledJob> jobs = scheduledJobs.get(id);
         // Iterate over jobs, cancelling and removing only those matching the job class.
-        for (ScheduledJob scheduledJob : jobs) {
+        // Use an iterator because elements may be removed and if removed in a regular loop it could
+        // throw a java.util.ConcurrentModificationException
+        // See https://stackoverflow.com/q/8104692/269834
+        for (Iterator<ScheduledJob> iterator = jobs.iterator(); iterator.hasNext(); ) {
+            ScheduledJob scheduledJob = iterator.next();
             if (clazz.isInstance(scheduledJob.job)) {
                 scheduledJob.scheduledFuture.cancel(mayInterruptIfRunning);
-                scheduledJobs.remove(id, scheduledJob);
+                iterator.remove();
                 jobsCancelled++;
             }
         }

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -219,7 +219,7 @@ public class FeedVersionController  {
         return true;
     }
 
-    private static Object downloadFeedVersionDirectly(Request req, Response res) {
+    private static HttpServletResponse downloadFeedVersionDirectly(Request req, Response res) {
         FeedVersion version = requestFeedVersion(req, "view");
         return downloadFile(version.retrieveGtfsFile(), version.id, req, res);
     }
@@ -232,7 +232,7 @@ public class FeedVersionController  {
         FeedVersion version = requestFeedVersion(req, "view");
 
         if (DataManager.useS3) {
-            // Return presigned download link if using S3.
+            // Return pre-signed download link if using S3.
             return downloadFromS3(FeedStore.s3Client, DataManager.feedBucket, FeedStore.s3Prefix + version.id, false, res);
         } else {
             // when feeds are stored locally, single-use download token will still be used

--- a/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
+++ b/src/main/java/com/conveyal/datatools/manager/controllers/api/FeedVersionController.java
@@ -14,22 +14,18 @@ import com.conveyal.datatools.manager.persistence.Persistence;
 import com.conveyal.datatools.manager.utils.HashUtils;
 import com.conveyal.datatools.manager.utils.json.JsonManager;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.io.ByteStreams;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import spark.Request;
 import spark.Response;
 
-import javax.servlet.ServletInputStream;
-import javax.servlet.ServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Date;
 
 import static com.conveyal.datatools.common.utils.S3Utils.downloadFromS3;
+import static com.conveyal.datatools.common.utils.SparkUtils.copyRequestStreamIntoFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.downloadFile;
 import static com.conveyal.datatools.common.utils.SparkUtils.formatJobMessage;
 import static com.conveyal.datatools.common.utils.SparkUtils.logMessageAndHalt;
@@ -101,34 +97,17 @@ public class FeedVersionController  {
         // FIXME: Make the creation of new GTFS files generic to handle other feed creation methods, including fetching
         // by URL and loading from the editor.
         File newGtfsFile = new File(DataManager.getConfigPropertyAsText("application.data.gtfs"), newFeedVersion.id);
-        try {
-            // Bypass Spark's request wrapper which always caches the request body in memory that may be a very large
-            // GTFS file. Also, the body of the request is the GTFS file instead of using multipart form data because
-            // multipart form handling code also caches the request body.
-            ServletInputStream inputStream = ((ServletRequestWrapper) req.raw()).getRequest().getInputStream();
-            FileOutputStream fileOutputStream = new FileOutputStream(newGtfsFile);
-            // Guava's ByteStreams.copy uses a 4k buffer (no need to wrap output stream), but does not close streams.
-            ByteStreams.copy(inputStream, fileOutputStream);
-            fileOutputStream.close();
-            inputStream.close();
-            if (newGtfsFile.length() == 0) {
-                throw new IOException("No file found in request body.");
-            }
-            // Set last modified based on value of query param. This is determined/supplied by the client
-            // request because this data gets lost in the uploadStream otherwise.
-            Long lastModified = req.queryParams("lastModified") != null
-                    ? Long.valueOf(req.queryParams("lastModified"))
-                    : null;
-            if (lastModified != null) {
-                newGtfsFile.setLastModified(lastModified);
-                newFeedVersion.fileTimestamp = lastModified;
-            }
-            LOG.info("Last modified: {}", new Date(newGtfsFile.lastModified()));
-            LOG.info("Saving feed from upload {}", feedSource);
-        } catch (Exception e) {
-            LOG.error("Unable to open input stream from uploaded file", e);
-            logMessageAndHalt(req, 400, "Unable to read uploaded feed");
+        copyRequestStreamIntoFile(req, newGtfsFile);
+        // Set last modified based on value of query param. This is determined/supplied by the client
+        // request because this data gets lost in the uploadStream otherwise.
+        Long lastModified = req.queryParams("lastModified") != null
+            ? Long.valueOf(req.queryParams("lastModified"))
+            : null;
+        if (lastModified != null) {
+            newGtfsFile.setLastModified(lastModified);
+            newFeedVersion.fileTimestamp = lastModified;
         }
+        LOG.info("Last modified: {}", new Date(newGtfsFile.lastModified()));
 
         // TODO: fix FeedVersion.hash() call when called in this context. Nothing gets hashed because the file has not been saved yet.
         // newFeedVersion.hash();

--- a/src/main/java/com/conveyal/datatools/manager/jobs/FetchProjectFeedsJob.java
+++ b/src/main/java/com/conveyal/datatools/manager/jobs/FetchProjectFeedsJob.java
@@ -40,6 +40,15 @@ public class FetchProjectFeedsJob extends MonitorableJob {
             if (!FeedSource.FeedRetrievalMethod.FETCHED_AUTOMATICALLY.equals(feedSource.retrievalMethod)) {
                 continue;
             }
+            // warn if a feed is setup to be fetched automatically, but doesn't have a url defined
+            if (feedSource.url == null) {
+                LOG.warn(
+                    "Feed '{}' ({}) is set to be fetched automatically, but lacks a url!",
+                    feedSource.name,
+                    feedSource.id
+                );
+                continue;
+            }
             // No need to track overall status on this FetchProjectFeedsJob. All "child" jobs execute in threadpool,
             // so we don't know their status.
             FetchSingleFeedJob fetchSingleFeedJob = new FetchSingleFeedJob(feedSource, owner, true);

--- a/src/main/java/com/conveyal/datatools/manager/models/FeedValidationResultSummary.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/FeedValidationResultSummary.java
@@ -27,8 +27,9 @@ public class FeedValidationResultSummary implements Serializable {
     // statistics
     public int agencyCount;
     public int routeCount;
-    public int tripCount;
+    public int stopCount;
     public int stopTimesCount;
+    public int tripCount;
     public long avgDailyRevenueTime;
 
     /** The first date the feed has service, either in calendar.txt or calendar_dates.txt */
@@ -59,6 +60,7 @@ public class FeedValidationResultSummary implements Serializable {
                 this.errorCount = validationResult.errorCount;
                 this.agencyCount = feedLoadResult.agency.rowCount;
                 this.routeCount = feedLoadResult.routes.rowCount;
+                this.stopCount = feedLoadResult.stops.rowCount;
                 this.tripCount = feedLoadResult.trips.rowCount;
                 this.stopTimesCount = feedLoadResult.stopTimes.rowCount;
                 this.startDate = validationResult.firstCalendarDate;

--- a/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
+++ b/src/main/java/com/conveyal/datatools/manager/persistence/FeedStore.java
@@ -171,6 +171,10 @@ public class FeedStore {
         return s3Prefix + id;
     }
 
+    public String getPathToFeed (String id) {
+        return new File(path, id).getAbsolutePath();
+    }
+
     /**
      * Get the feed with the given ID.
      */


### PR DESCRIPTION
Fixes GTFS+ upload and publication (version creation). Basically, the GTFS+ code was never fully updated for the Mongo + RDBMS changes, so this seeks to finish that work. This is why, for example, it may appear strange that the ProcessSingleFeedJob is being added to the publish controller, when it didn't previously exist.

This works in conjunction with conveyal/datatools-ui#382.

It also adds stop count to validation summary.