### PR TITLE
Use ConcurrentHashSet for tracking scheduled jobs

### DIFF
--- a/src/main/java/com/conveyal/datatools/common/utils/ScheduledJob.java
+++ b/src/main/java/com/conveyal/datatools/common/utils/ScheduledJob.java
@@ -1,15 +1,26 @@
 package com.conveyal.datatools.common.utils;
 
+import com.conveyal.datatools.manager.models.FeedSource;
+import com.conveyal.datatools.manager.models.Project;
+
 import java.util.concurrent.ScheduledFuture;
 
 /**
  * Utility class that associates a {@link Runnable} with its {@link ScheduledFuture} for easy storage and recall.
  */
 public class ScheduledJob {
+    public final String id;
     public final ScheduledFuture scheduledFuture;
     public final Runnable job;
 
-    public ScheduledJob (Runnable job, ScheduledFuture scheduledFuture) {
+    ScheduledJob (FeedSource feedSource, Runnable job, ScheduledFuture scheduledFuture) {
+        this.id = feedSource.id;
+        this.job = job;
+        this.scheduledFuture = scheduledFuture;
+    }
+
+    ScheduledJob (Project project, Runnable job, ScheduledFuture scheduledFuture) {
+        this.id = project.id;
         this.job = job;
         this.scheduledFuture = scheduledFuture;
     }

--- a/src/main/java/com/conveyal/datatools/manager/DataManager.java
+++ b/src/main/java/com/conveyal/datatools/manager/DataManager.java
@@ -86,7 +86,7 @@ public class DataManager {
      * Stores jobs underway by user ID. NOTE: any set created and stored here must be created with
      * {@link Sets#newConcurrentHashSet()} or similar thread-safe Set.
      */
-    public static Map<String, Set<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
+    public static final Map<String, Set<MonitorableJob>> userJobsMap = new ConcurrentHashMap<>();
 
     // ObjectMapper that loads in YAML config files
     private static final ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());


### PR DESCRIPTION
Fixes #166 by replacing the ListMultimap with a ConcurrentHashSet to track scheduled jobs.