### PR TITLE
Deployment fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ script:
 after_success:
   # this first codecov run will upload a report associated with the commit set through Travis CI environment variables
   - bash <(curl -s https://codecov.io/bash)
-  # run maven-semantic-release to potentially create a new release of gtfs-lib.
+  # run maven-semantic-release to potentially create a new release of datatools-server. The flag --skip-maven-deploy is
+  # used to avoid deploying to maven central. So essentially, this just creates a release with a changelog on github.
   #
   # If maven-semantic-release finishes successfully and the current branch is master, upload coverage reports for the
   # commits that maven-semantic-release generated. Since the above codecov run is associated with the commit that

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ after_success:
   #
   # The git commands get the commit hash of the HEAD commit and the commit just before HEAD.
   - |
-    semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev
+    semantic-release --prepare @conveyal/maven-semantic-release --publish @semantic-release/github,@conveyal/maven-semantic-release --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release --verify-release @conveyal/maven-semantic-release --use-conveyal-workflow --dev-branch=dev --skip-maven-deploy
     if [[ "$TRAVIS_BRANCH" = "master" ]]; then
       bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD)"
       bash <(curl -s https://codecov.io/bash) -C "$(git rev-parse HEAD^)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,15 @@ notifications:
 before_deploy:
 # get branch name of current branch for use in jar name: https://graysonkoonce.com/getting-the-current-branch-name-during-a-pull-request-in-travis-ci/
 - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo $TRAVIS_PULL_REQUEST_BRANCH; fi)
-# copy packaged jars over to deploy dir
+# Create directory that will contain artifacts to deploy to s3.
 - mkdir deploy
+# Display contents of target directory (for logging purposes only).
+- ls target/*.jar
+# Copy packaged jars over to deploy dir.
 - cp target/dt-*.jar deploy/
-- cp "target/dt-$(git describe --always).jar" "deploy/dt-latest-${BRANCH}.jar"
+# FIXME: Do not create a branch-specific jar for now. Having a jar that changes contents but keeps the same name
+#   may cause confusion down the road and may be undesirable.
+# - cp "target/dt-$(git describe --always).jar" "deploy/dt-latest-${BRANCH}.jar"
 deploy:
   provider: s3
   skip_cleanup: true


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

- Fixes an accidentally removed a flag in the command to maven-semantic-release that would have prevented deployment to maven central. Offending PR here: #178.
- Adds more comments in .travis.yml to document maven-semantic-release deployment process
- Uploads all (`dt-*.jar`) jars found in the target directory. refs #181 (but I'm not calling this a fix yet).