### PR TITLE
Add pinned deployments to projects

### DIFF
--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -63,6 +63,8 @@ public class Project extends Model {
     // and/or for applying a geographic filter when syncing with external feed registries.
     public Bounds bounds;
 
+    public String pinnedDeploymentId;
+
     public Project() {
         this.buildConfig = new OtpBuildConfig();
         this.routerConfig = new OtpRouterConfig();

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -63,6 +63,7 @@ public class Project extends Model {
     // and/or for applying a geographic filter when syncing with external feed registries.
     public Bounds bounds;
 
+    // used to identify a specific deployment. A bunch of UI things depend on this.
     public String pinnedDeploymentId;
 
     public Project() {

--- a/src/main/java/com/conveyal/datatools/manager/models/Project.java
+++ b/src/main/java/com/conveyal/datatools/manager/models/Project.java
@@ -63,7 +63,10 @@ public class Project extends Model {
     // and/or for applying a geographic filter when syncing with external feed registries.
     public Bounds bounds;
 
-    // used to identify a specific deployment. A bunch of UI things depend on this.
+    // Identifies a specific "pinned" deployment for the project. This is used in datatools-ui in 2 places:
+    // 1. In the list of project deployments, a "pinned" deployment is shown first and highlighted.
+    // 2. In the project feed source table, if a "pinned" deployment exists, the status of the versions that were in
+    //   the "pinned" deployment are shown and compared to the most recent version in the feed sources.
     public String pinnedDeploymentId;
 
     public Project() {


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This change allows the persistence of a pinned deployment. Pinned deployments are being added to help complete https://github.com/conveyal/datatools-ui/issues/422. The pinned deployment is sometimes used to compare feed versions within the app in and in a specific deployment.

These changes assume that the deployment module is enabled in the UI.