### PR TITLE
Bump gtfs-lib to 4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,7 +247,7 @@
         <dependency>
             <groupId>com.conveyal</groupId>
             <artifactId>gtfs-lib</artifactId>
-            <version>4.2.5</version>
+            <version>4.3.0</version>
         </dependency>
 
         <!-- Used for data-tools application database -->


### PR DESCRIPTION
### Checklist

- [x] Appropriate branch selected _(all PRs must first be merged to `dev` before they can be merged to `master`)_
- [x] Any modified or new methods or classes have helpful JavaDoc and code is thoroughly commented
- [x] The description lists all applicable issues this PR seeks to resolve
- [x] The description lists any configuration setting(s) that differ from the default settings
- [x] All tests and CI builds passing

### Description

This bumps the gtfs-lib version to [4.3.0](https://github.com/conveyal/gtfs-lib/releases/tag/v4.3.0). This version has a number of bug fixes and enhancements for MTC.